### PR TITLE
Use hex setting when using the textbox

### DIFF
--- a/javascripts/mColorPicker.js
+++ b/javascripts/mColorPicker.js
@@ -146,7 +146,9 @@
 
     }).live('blur', function () {
   
-      $o.currentInput.mSetInputColor($o.color);
+      var $e = $o.currentInput;
+      
+      $e.mSetInputColor($.fn.mColorPicker.setColor($o.color, ($e.attr('data-hex') || $e.attr('hex'))));
     });
   
     $('#mColorPickerWrapper').live('mouseleave', function () {


### PR DESCRIPTION
Currently even if hex is set to true, the text box is setting it back to rgb